### PR TITLE
Parquet s3 destination - Continuously writing data to s3 without waiting for all data to be written at file system.

### DIFF
--- a/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_definitions.yaml
@@ -113,5 +113,5 @@
 - destinationDefinitionId: 48e72244-f2f7-11eb-9a03-0242ac130003
   name: S3-Parquet
   dockerRepository: blotout/destination-s3-parquet
-  dockerImageTag: 0.1.4
+  dockerImageTag: 0.1.6
   documentationUrl: https://docs.airbyte.io/integrations/destinations/s3

--- a/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
+++ b/airbyte-config/init/src/main/resources/seed/destination_specs.yaml
@@ -3049,7 +3049,7 @@
     - "overwrite"
     - "append"
     - "append_dedup"
-- dockerImage: "blotout/destination-s3-parquet:0.1.4"
+- dockerImage: "blotout/destination-s3-parquet:0.1.6"
   spec:
     "documentationUrl": "https://docs.airbyte.io/integrations/destinations/s3"
     "supportsIncremental": true

--- a/airbyte-integrations/connectors/destination-s3-parquet/Dockerfile
+++ b/airbyte-integrations/connectors/destination-s3-parquet/Dockerfile
@@ -12,5 +12,5 @@ RUN pip install .
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 ENTRYPOINT ["python", "/airbyte/integration_code/main.py"]
 
-LABEL io.airbyte.version=0.1.4
+LABEL io.airbyte.version=0.1.6
 LABEL io.airbyte.name=blotout/destination-s3-parquet

--- a/airbyte-integrations/connectors/destination-s3-parquet/destination_s3_parquet/destination.py
+++ b/airbyte-integrations/connectors/destination-s3-parquet/destination_s3_parquet/destination.py
@@ -84,7 +84,7 @@ class DestinationS3Parquet(Destination):
     ) -> Iterable[AirbyteMessage]:
 
         for configured_stream in configured_catalog.streams:
-            LOGGER.info('stream name all' + configured_stream.stream.name)
+            LOGGER.info('stream name ' + configured_stream.stream.name)
 
         config = dict(config)
         s3_client = s3.create_client(config)
@@ -184,11 +184,11 @@ class DestinationS3Parquet(Destination):
             if record_unique_field and record_unique_field in df:
                 unique_ids_already_processed = read_temp_pickle()
                 df = df[~df[record_unique_field].isin(unique_ids_already_processed)]
-                LOGGER.info('df filtered size: {}'.format(df.shape))
+                # LOGGER.info('df filtered size: {}'.format(df.shape))
                 df = df.drop_duplicates()
                 #LOGGER.info('df after drop_duplicates size: {}'.format(df.shape))
                 # df = df.groupby(record_unique_field).first().reset_index()
-                LOGGER.info('df first record of each unique_id size: {}'.format(df.shape))
+                # LOGGER.info('df first record of each unique_id size: {}'.format(df.shape))
                 new_unique_ids = set(df[record_unique_field].unique())
                 #LOGGER.info('unique_ids_already_processed: {}, new_unique_ids: {}'.format(
                     #len(unique_ids_already_processed), len(new_unique_ids)))


### PR DESCRIPTION
## What is the change ?
Old implementation first write data in json format on local machines for all streams and once all data is received then it writes data to s3 using json files. Updated logic in new implementation is continuously writing data to s3 without waiting for all data to be written on file system.

## What is solves ? 
Old implementation was leading to high volume usage on machine, but as current implementation writes data directly, hence it will reduce the disk usage footprint on machine.
